### PR TITLE
fix: Don't default to selected when discovering catalog

### DIFF
--- a/tap_nikabot/streams/stream.py
+++ b/tap_nikabot/streams/stream.py
@@ -35,8 +35,6 @@ class Stream(ABC):
             self.key_properties,
             valid_replication_keys=[self.replication_key] if self.replication_key else None,
         )
-        # Default to selected
-        stream_metadata = metadata.to_list(metadata.write(metadata.to_map(stream_metadata), (), "selected", True))
         catalog_entry = CatalogEntry(
             tap_stream_id=self.stream_id,
             stream=self.stream_id,


### PR DESCRIPTION
# Description of change
When setting up the tap on stitch data, the following error is received:

```
2020-11-11 21:12:19,504Z   main - INFO Saving list of discovered streams
2020-11-11 21:12:19,557Z   main - INFO Saving structure of stream users (tap_stream_id: users)
2020-11-11 21:12:19,602Z   main - CRITICAL Error saving discovered stream users: {"invalid_fields":"Non-discoverable metadata can not be discovered: #{\"selected\"}"}
```

This is likely because I was added `"selected": true` to the metadata for each stream.

# Manual QA steps
Ran the following

```
tap-nikabot -c config.json --discover > catalog.json
```

and checked that it no longer adds the selected property to metadata. Need to test on stitch data once released.
 
# Risks
Very minimal, adding the selected property was just to help with testing.
 
# Rollback steps
 - revert this branch
