### PR TITLE
Remove schema name

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -62,6 +62,7 @@
           "role": {
             "type": "string"
           },
+          "settings": {},
           "team_id": {
             "type": "string"
           },
@@ -79,6 +80,9 @@
             "format": "date-time",
             "type": "string"
           },
+          "userType": {
+            "type": "string"
+          },
           "user_id": {
             "type": "string"
           }
@@ -93,9 +97,7 @@
             "table-key-properties": [
               "id"
             ],
-            "inclusion": "available",
-            "schema-name": "users",
-            "selected": true
+            "inclusion": "available"
           }
         },
         {
@@ -245,6 +247,15 @@
         {
           "breadcrumb": [
             "properties",
+            "settings"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
             "team_id"
           ],
           "metadata": {
@@ -290,6 +301,15 @@
         {
           "breadcrumb": [
             "properties",
+            "userType"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
             "user_id"
           ],
           "metadata": {
@@ -325,9 +345,7 @@
             "table-key-properties": [
               "id"
             ],
-            "inclusion": "available",
-            "schema-name": "roles",
-            "selected": true
+            "inclusion": "available"
           }
         },
         {
@@ -386,9 +404,7 @@
             "table-key-properties": [
               "id"
             ],
-            "inclusion": "available",
-            "schema-name": "groups",
-            "selected": true
+            "inclusion": "available"
           }
         },
         {
@@ -447,6 +463,7 @@
           "platform_id": {
             "type": "string"
           },
+          "settings": {},
           "status": {
             "type": "string"
           },
@@ -462,9 +479,7 @@
             "table-key-properties": [
               "id"
             ],
-            "inclusion": "available",
-            "schema-name": "teams",
-            "selected": true
+            "inclusion": "available"
           }
         },
         {
@@ -525,6 +540,15 @@
           "breadcrumb": [
             "properties",
             "platform_id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "settings"
           ],
           "metadata": {
             "inclusion": "available"
@@ -605,9 +629,7 @@
             "table-key-properties": [
               "id"
             ],
-            "inclusion": "available",
-            "schema-name": "projects",
-            "selected": true
+            "inclusion": "available"
           }
         },
         {
@@ -722,7 +744,6 @@
     },
     {
       "tap_stream_id": "records",
-      "replication_method": "FULL_TABLE",
       "key_properties": [
         "id"
       ],
@@ -781,12 +802,7 @@
             "table-key-properties": [
               "id"
             ],
-            "valid-replication-keys": [
-              "date"
-            ],
-            "inclusion": "available",
-            "schema-name": "records",
-            "selected": true
+            "inclusion": "available"
           }
         },
         {

--- a/tap_nikabot/streams/stream.py
+++ b/tap_nikabot/streams/stream.py
@@ -20,12 +20,6 @@ from ..typing import JsonResult
 LOGGER = singer.get_logger()
 
 
-def remove_schema_name(stream_metadata: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    compiled_metadata = metadata.to_map(stream_metadata)
-    metadata.delete(compiled_metadata, (), "schema-name")
-    return cast(List[Dict[str, Any]], metadata.to_list(compiled_metadata))
-
-
 class Stream(ABC):
     stream_id: str = ""
     key_properties: List[str] = ["id"]
@@ -37,13 +31,10 @@ class Stream(ABC):
     def get_catalog_entry(self, swagger: JsonResult) -> CatalogEntry:
         schema = self._map_to_schema(swagger)
         stream_metadata = metadata.get_standard_metadata(
-            schema.to_dict(),
-            self.stream_id,
-            self.key_properties,
+            schema=schema.to_dict(),
+            key_properties=self.key_properties,
             valid_replication_keys=[self.replication_key] if self.replication_key else None,
         )
-        # FIX: Remove schema_name else it breaks stitch data website
-        remove_schema_name(stream_metadata)
         catalog_entry = CatalogEntry(
             tap_stream_id=self.stream_id,
             stream=self.stream_id,

--- a/tap_nikabot/streams/stream.py
+++ b/tap_nikabot/streams/stream.py
@@ -5,7 +5,6 @@ from typing import (
     Iterator,
     List,
     Optional,
-    cast,
 )
 
 import singer

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -53,3 +53,9 @@ class TestDiscover:
         assert catalog_entry.stream == "records"
         assert catalog_entry.schema.properties["hours"] is not None
         assert catalog_entry.schema.properties["edited"].properties["date"].type == "string"
+
+    def test_metadata_should_not_have_schema_name(self):
+        catalog = discover()
+        catalog_dict = catalog.to_dict()
+        has_schema_name = any(e for e in catalog_dict["streams"] if "schema-name" in e["metadata"][0]["metadata"])
+        assert not has_schema_name


### PR DESCRIPTION
# Description of change
The current catalog / schema breaks the stitch data website, to replicate:
- Add a new integration using the Nikabot tap. 
- Select "Choose Tables to Replicate"
- Select a "Database" (it should say "Table")

Expect to see "Field Names" to select. 

Actually see "Schema Names" with one option "0" (see screenshots)

After some trial and error I believe I've narrowed it down to a "schema-name" property in the stream metadata. The schema-name property is being added from 

```
stream_metadata = metadata.get_standard_metadata(
    schema.to_dict(),
    self.stream_id,   # <- This is setting the schema-name
    self.key_properties,
    valid_replication_keys=[self.replication_key] if self.replication_key else None,
)
```

This change removes the `schema-name` property from all stream's metadata.

# Manual QA steps
 - Added relevant unit test and check others pass.
 - Ran discover mode and generated a `catalog.json`, compared to previous one and the only difference was the missing `schema-name` property.
 - Ran ZAP Proxy to manipulate `streams` API on the stitch data website and removed the `schema-name` property, everything worked as expected.
 
# Risks
 - Low to none, the catalog is mostly used by stitch data website which is still broken
 
# Rollback steps
 - revert this branch

# Screenshots

## Current behaviour

<img width="1440" alt="Screen Shot 2021-03-24 at 9 47 25 pm" src="https://user-images.githubusercontent.com/1317277/112302240-f5ddf000-8cee-11eb-8891-48f8cc09ec74.png">

<img width="1440" alt="Screen Shot 2021-03-24 at 9 46 51 pm" src="https://user-images.githubusercontent.com/1317277/112302263-fecec180-8cee-11eb-9153-9f82491d8bd9.png">

<img width="1440" alt="Screen Shot 2021-03-24 at 9 49 37 pm" src="https://user-images.githubusercontent.com/1317277/112302284-01c9b200-8cef-11eb-86c3-f391dbe9ad17.png">

## Removing schema-name property

<img width="1440" alt="Screen Shot 2021-03-24 at 10 20 24 pm" src="https://user-images.githubusercontent.com/1317277/112302502-43f2f380-8cef-11eb-9b20-77af835a5afe.png">

<img width="1440" alt="Screen Shot 2021-03-24 at 10 20 34 pm" src="https://user-images.githubusercontent.com/1317277/112302516-48b7a780-8cef-11eb-8fec-c79f6b3209e3.png">

