### PR TITLE
fix: Fix error when end date is empty string

### DIFF
--- a/tap_nikabot/streams/records.py
+++ b/tap_nikabot/streams/records.py
@@ -46,7 +46,7 @@ class Records(Stream):
         self.validate_replication_method(replication_method)
 
         start_date = date.min
-        if "start_date" in config:
+        if "start_date" in config and config["start_date"]:
             start_date = isoparse(config["start_date"]).date()
 
         end_date = date.max

--- a/tap_nikabot/streams/records.py
+++ b/tap_nikabot/streams/records.py
@@ -50,7 +50,7 @@ class Records(Stream):
             start_date = isoparse(config["start_date"]).date()
 
         end_date = date.max
-        if "end_date" in config:
+        if "end_date" in config and config["end_date"]:
             end_date = isoparse(config["end_date"]).date()
             if end_date < start_date:
                 raise StartDateAfterEndDateError(start_date, end_date)

--- a/tests/test_sync_records.py
+++ b/tests/test_sync_records.py
@@ -128,6 +128,21 @@ class TestSyncRecords:
             ),
         ]
 
+    def test_should_not_error_when_end_date_is_empty(self, requests_mock, mock_catalog):
+        requests_mock.get(
+            "https://api.nikabot.com/api/v1/records?limit=1000&page=0&dateStart=20200611&dateEnd=99991231",
+            json=json.loads(EMPTY_RESPONSE),
+        )
+        config = {
+            "access_token": "my-access-token",
+            "page_size": 1000,
+            "start_date": "2020-06-11",
+            "end_date": "",
+        }
+        state = {}
+        sync(config, state, mock_catalog)
+        assert requests_mock.call_count == 1
+
     def test_should_raise_error_when_start_date_greater_than_end_date(self, mock_catalog):
         config = {
             "access_token": "my-access-token",

--- a/tests/test_sync_records.py
+++ b/tests/test_sync_records.py
@@ -128,15 +128,15 @@ class TestSyncRecords:
             ),
         ]
 
-    def test_should_not_error_when_end_date_is_empty(self, requests_mock, mock_catalog):
+    def test_should_not_error_when_start_or_end_date_is_empty(self, requests_mock, mock_catalog):
         requests_mock.get(
-            "https://api.nikabot.com/api/v1/records?limit=1000&page=0&dateStart=20200611&dateEnd=99991231",
+            "https://api.nikabot.com/api/v1/records?limit=1000&page=0&dateStart=00010101&dateEnd=99991231",
             json=json.loads(EMPTY_RESPONSE),
         )
         config = {
             "access_token": "my-access-token",
             "page_size": 1000,
-            "start_date": "2020-06-11",
+            "start_date": "",
             "end_date": "",
         }
         state = {}


### PR DESCRIPTION
# Description of change
If config value for `end_date` is an empty string, fetching records throws an error.

# Manual QA steps
 - Set config value for `"end_date": ""`
 - Run a sync with records selected:
 
```
tap-nikabot -c config.json --catalog catalog.json
```

## Expected result
No error raised, all records from start date till end of time returned

## Actual result
Error raised: 

```
  File "/Users/paul/Projects/tap-nikabot/tap_nikabot/streams/records.py", line 54, in get_records
    end_date = isoparse(config["end_date"]).date()
  File "/Users/paul/Projects/tap-nikabot/.venv/lib/python3.9/site-packages/dateutil/parser/isoparser.py", line 37, in func
    return f(self, str_in, *args, **kwargs)
  File "/Users/paul/Projects/tap-nikabot/.venv/lib/python3.9/site-packages/dateutil/parser/isoparser.py", line 134, in isoparse
    components, pos = self._parse_isodate(dt_str)
  File "/Users/paul/Projects/tap-nikabot/.venv/lib/python3.9/site-packages/dateutil/parser/isoparser.py", line 210, in _parse_isodate
    return self._parse_isodate_uncommon(dt_str)
  File "/Users/paul/Projects/tap-nikabot/.venv/lib/python3.9/site-packages/dateutil/parser/isoparser.py", line 255, in _parse_isodate_uncommon
    raise ValueError('ISO string too short')
ValueError: ISO string too short
```
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
